### PR TITLE
fix(cli): ensure analyze temp cleanup on skip path

### DIFF
--- a/packages/cli/src/commands/analyze.test.ts
+++ b/packages/cli/src/commands/analyze.test.ts
@@ -144,18 +144,9 @@ describe('analyzeProject command', () => {
 
       vi.mocked(getAnyNodeByProjectBranchVersion).mockResolvedValue(existingNode as any)
 
-      // Mock process.exit to throw an error to stop execution
-      const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
-        throw new Error(`Process exited with code ${code}`)
-      })
+      await expect(analyzeProject()).resolves.toBeUndefined()
 
-      // Expect the function to throw due to process.exit
-      await expect(analyzeProject()).rejects.toThrow('Process exited with code 0')
-
-      expect(mockExit).toHaveBeenCalledWith(0)
       expect(runCodeQL).not.toHaveBeenCalled()
-
-      mockExit.mockRestore()
     })
   })
 
@@ -241,6 +232,18 @@ describe('analyzeProject command', () => {
 
       await expect(analyzeProject()).rejects.toThrow()
 
+      expect(rmSync).toHaveBeenCalledWith('/tmp/test/repo', { recursive: true })
+    })
+
+    it('should cleanup for remote repos when analysis is skipped due to existing node', async () => {
+      mockContext.isRemote = () => true
+      const { directoryExistsSync } = await import('../utils/fs-helper')
+      vi.mocked(directoryExistsSync).mockReturnValue(true)
+      vi.mocked(getAnyNodeByProjectBranchVersion).mockResolvedValue({ qlsVersion: 'v1.0.0' } as any)
+
+      await expect(analyzeProject()).resolves.toBeUndefined()
+
+      expect(runCodeQL).not.toHaveBeenCalled()
       expect(rmSync).toHaveBeenCalledWith('/tmp/test/repo', { recursive: true })
     })
   })

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -26,7 +26,7 @@ export async function analyzeProject(): Promise<void> {
 
     if (node && node?.qlsVersion === ctx.getQlsVersion()) {
       debug(`already existing nodes for version: ${ctx.getVersion()}, qls: ${ctx.getQlsVersion()}`)
-      process.exit(0)
+      return
     }
 
     // Handle monorepo package name search


### PR DESCRIPTION
## Summary
- fix analyzer temp directory leak when analyze short-circuits on existing node
- replace `process.exit(0)` with normal `return` so `finally` cleanup always runs
- update analyze tests to assert graceful skip path and cleanup behavior

## Root cause
`analyzeProject` used `process.exit(0)` in the skip path. That can bypass normal function unwinding and prevent `finally` cleanup, leaving `dependency-analyzer-*` temporary folders.

## Validation
- logic verified against code path: `return` keeps control flow inside function and executes `finally` cleanup
- branch commit: `f007ef7`

## Risk
Low. Behavior is unchanged except exit mechanism in the skip path, now cleanup-safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of existing analysis nodes—the analyze command now gracefully completes instead of forcefully terminating the process when a matching node is detected.

* **Tests**
  * Updated test suite to reflect improved error handling and cleanup behavior for remote repositories during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->