### PR TITLE
fix(cli): let MCP SDK manage session id to avoid uninitialized streamable HTTP errors

### DIFF
--- a/packages/cli/src/llm/mcp-client.ts
+++ b/packages/cli/src/llm/mcp-client.ts
@@ -1,12 +1,9 @@
 import { MultiServerMCPClient } from '@langchain/mcp-adapters'
-import { randomUUID } from 'crypto'
 import debug, { error } from '../utils/debug'
 import type { GitRepoConfig } from '../api'
 
 let mcpClient: MultiServerMCPClient | null = null
 let projectIdToConfigMap: Map<string, GitRepoConfig> = new Map()
-// Store session ID to reuse across requests and for cleanup
-let sessionId: string | null = null
 
 // MCP endpoint - constructed from host and port
 const MCP_SERVER_HOST = process.env.MCP_SERVER_HOST || '127.0.0.1'
@@ -28,10 +25,6 @@ export async function initMCPClient(configMap: Map<string, GitRepoConfig>) {
   debug('Initializing GitLab MCP client with endpoint: %s', MCP_ENDPOINT)
   projectIdToConfigMap = configMap
 
-  // Generate a persistent session ID for this client instance
-  sessionId = randomUUID()
-  debug('Generated MCP session ID: %s', sessionId)
-
   if (configMap.size === 0) {
     throw new Error('At least one GitRepo configuration is required to initialize MCP client')
   }
@@ -49,7 +42,6 @@ export async function initMCPClient(configMap: Map<string, GitRepoConfig>) {
         headers: {
           Authorization: `Bearer ${firstConfig.accessToken}`,
           'X-GitLab-API-URL': firstConfig.apiUrl,
-          'mcp-session-id': sessionId, // Inject session ID to reuse session
         },
       },
     },
@@ -80,14 +72,44 @@ export async function initMCPClient(configMap: Map<string, GitRepoConfig>) {
         headers: {
           Authorization: `Bearer ${matchingConfig.accessToken}`,
           'X-GitLab-API-URL': matchingConfig.apiUrl,
-          'mcp-session-id': sessionId!, // Ensure session ID is preserved in tool calls
         },
       }
     },
   })
 
-  // Load tools from the MCP server
-  const tools = await mcpClient.getTools()
+  // Load tools from the MCP server.
+  // The MCP process can report healthy slightly before transport/session init is fully ready,
+  // so we retry briefly on transient initialization errors.
+  let tools: Awaited<ReturnType<MultiServerMCPClient['getTools']>> = []
+  let lastError: unknown
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    try {
+      tools = await mcpClient.getTools()
+      break
+    } catch (err) {
+      lastError = err
+      const message = err instanceof Error ? err.message : String(err)
+      const isInitRace =
+        message.includes('Server not initialized') ||
+        message.includes('Failed to connect to streamable HTTP server')
+
+      if (!isInitRace || attempt === 5) {
+        throw err
+      }
+
+      debug(
+        'MCP init race on attempt %d/5 (%s); retrying in 500ms...',
+        attempt,
+        message,
+      )
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+  }
+
+  if (tools.length === 0 && lastError) {
+    throw lastError instanceof Error ? lastError : new Error(String(lastError))
+  }
+
   debug(`MCP client initialized with ${tools.length} tools: ${tools.map((t) => t.name).join(', ')}`)
 
   return mcpClient
@@ -116,32 +138,13 @@ export async function closeMCPClient(): Promise<void> {
   try {
     await mcpClient.close()
 
-    // Explicitly close the session on the server
-    if (sessionId) {
-      try {
-        debug('Explicitly closing session %s on server...', sessionId)
-        await fetch(MCP_ENDPOINT, {
-          method: 'DELETE',
-          headers: {
-            'mcp-session-id': sessionId
-          }
-        })
-        debug('Session closed successfully on server')
-      } catch (err) {
-        // Log but don't fail if cleanup fails (server might be down already)
-        debug('Warning: Failed to close remote session: %o', err)
-      }
-    }
-
     mcpClient = null
-    sessionId = null
     projectIdToConfigMap.clear()
     debug('MCP client closed successfully')
   } catch (error) {
     debug('Error closing MCP client: %o', error)
     // Still set to null to allow re-initialization
     mcpClient = null
-    sessionId = null
     projectIdToConfigMap.clear()
   }
 }

--- a/packages/cli/src/llm/mcp-client.ts
+++ b/packages/cli/src/llm/mcp-client.ts
@@ -136,6 +136,24 @@ export async function closeMCPClient(): Promise<void> {
 
   debug('Closing MCP client...')
   try {
+    // Explicitly terminate the server-side MCP session before closing local client resources.
+    // The SDK's StreamableHTTPClientTransport supports DELETE /mcp via terminateSession().
+    try {
+      const gitlabClient = await mcpClient.getClient('gitlab')
+      const transport = (gitlabClient as { transport?: { terminateSession?: () => Promise<void> } })
+        ?.transport
+
+      if (transport?.terminateSession) {
+        await transport.terminateSession()
+        debug('MCP server session terminated explicitly via DELETE /mcp')
+      } else {
+        debug('MCP transport does not support terminateSession(), skipping explicit server session close')
+      }
+    } catch (terminateError) {
+      // Best effort only. Continue with normal close path.
+      debug('Failed to terminate MCP server session explicitly: %o', terminateError)
+    }
+
     await mcpClient.close()
 
     mcpClient = null

--- a/packages/cli/src/llm/mcp-client.ts
+++ b/packages/cli/src/llm/mcp-client.ts
@@ -144,7 +144,12 @@ export async function closeMCPClient(): Promise<void> {
         ?.transport
 
       if (transport?.terminateSession) {
-        await transport.terminateSession()
+        await Promise.race([
+          transport.terminateSession(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('MCP terminateSession timeout after 3000ms')), 3000),
+          ),
+        ])
         debug('MCP server session terminated explicitly via DELETE /mcp')
       } else {
         debug('MCP transport does not support terminateSession(), skipping explicit server session close')


### PR DESCRIPTION
## Summary
This PR fixes intermittent MCP connection failures against the GitLab MCP server:

- `Bad Request: Server not initialized`
- fallback SSE 404 after streamable-http failure

## Root cause
The CLI MCP client manually injected `mcp-session-id` headers.

In the MCP SDK streamable HTTP client, internal session headers are merged first and user-provided headers are merged after, so a manually provided `mcp-session-id` overrides SDK-managed session state. That can send requests against a non-existent/uninitialized session and trigger server-side initialization errors.

## Changes
- Remove custom `mcp-session-id` generation/injection from `packages/cli/src/llm/mcp-client.ts`
  - initial client headers
  - per-tool-call `beforeToolCall` headers
  - explicit DELETE-by-session cleanup logic
- Add transient retry around initial `getTools()` (5 attempts, 500ms backoff) for startup race windows where MCP process is healthy but transport/session setup is still warming up.

## Why this is the best fix
- Preserves MCP protocol lifecycle as intended by SDK
- Avoids session desynchronization between client and server
- Keeps auth + dynamic API URL header injection intact
- Improves resilience without changing tool semantics

## Validation
- `pnpm -C packages/cli test`
  - 5 test files passed
  - 39 tests passed, 1 skipped

## Notes
Current workspace used `@zereight/mcp-gitlab@2.0.22`; optional follow-up could bump to latest for additional upstream fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client startup reliability with automatic retry (up to 5 attempts with backoff) to handle transient tool-initialization failures.
  * More robust shutdown behavior that best-effort terminates server-side work and ensures local cleanup even on errors.

* **Improvements**
  * Streamlined session handling to simplify operations and reduce reliance on persistent server-side session headers.

* **New Features**
  * Public API to retrieve the current MCP client instance for external use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->